### PR TITLE
Set /nubis directory to be world writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /nubis
 
+# Allow everyone to write and copy to that directory
+RUN chmod 777 /nubis
+
 # Install the AWS cli tool
 RUN pip install awscli==${AwCliVersion}
 


### PR DESCRIPTION
The instructions right now has `-u $UID:$(id -g)` if we dont set `/nubis` to `0777` the builder will fail.  This fixes it

Fixes #13 